### PR TITLE
The h_block_save snippet name had a small error

### DIFF
--- a/snippets/drupal.snippets
+++ b/snippets/drupal.snippets
@@ -1549,7 +1549,7 @@ snippet h_block_configure
 	  }
 	  return $form;
 	}
-snippet h_block_save($delta = '', $edit = array
+snippet h_block_save
 	/**
 	 * Implements hook_block_save($delta = '', $edit = array().
 	 */


### PR DESCRIPTION
looks like the generator script may have been confused by the default arg set to an array()
